### PR TITLE
change port for scanner connection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=<project-key>
 sonar.projectName=<project-name>
 sonar.sources=.
-sonar.host.url=http://portal:9123
+sonar.host.url=http://portal:9000
 sonar.token=<your-token>
 sonar.sourceEncoding=UTF-8
 sonar.projectVersion=1.0


### PR DESCRIPTION
Change port in the example file `sonar-project.propertie` pro the service SonarQube from 9123 to 9000 due to access in the docker network.